### PR TITLE
add charset declarations

### DIFF
--- a/AGPL-3.0.html
+++ b/AGPL-3.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>GNU Affero General Public License, version 3.0</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
   <link rel="stylesheet" href="gpls.css">

--- a/Apache-2.0.html
+++ b/Apache-2.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>Apache License, Version 2.0</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/CC0-1.0.html
+++ b/CC0-1.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>CC0 1.0 Universal</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/CERN-OHL-P-2.0.html
+++ b/CERN-OHL-P-2.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>CERN Open Hardware License Version 2 — Permissive</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/CERN-OHL-S-2.0.html
+++ b/CERN-OHL-S-2.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>CERN Open Hardware License Version 2 — Strongly Reciprocal</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/CERN-OHL-W-2.0.html
+++ b/CERN-OHL-W-2.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>CERN Open Hardware License Version 2 — Weakly Reciprocal</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/GPL-2.0.html
+++ b/GPL-2.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>GNU General Public License, version 2.0</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/GPL-3.0.html
+++ b/GPL-3.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>GNU General Public License, version 3.0</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
   <link rel="stylesheet" href="gpls.css">

--- a/MOPLA-1.1.html
+++ b/MOPLA-1.1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>Mozilla Open Software Patent License Agreement v1.1</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>

--- a/OSL-3.0.html
+++ b/OSL-3.0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>Open Software License v. 3.0</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
   <style>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <title>Public License Zoo</title>
   <link rel="stylesheet" href="https://readable.kemitchell.com/all.css">
 </head>


### PR DESCRIPTION
Some unicode characters (like © and directional quotes) are getting mangled by a lack of
charset declaration. This sets it to UTF-8 to fix that.